### PR TITLE
Parche de ejecución de pruebas para nuevos algoritmos que se implementen

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,4 +34,5 @@ jobs:
         make
     - name: Test with pytest
       run: |
-        pytest
+        # pytest-ing file by file
+        find tests/ -name "*.py" -exec pytest {} \;

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,14 @@ CC = g++
 CFLAGS = -fPIC -Wall
 LDFLAGS = -shared
 
-all: libeuclidean.so
+all: libeuclidean.so libmanhattan.so
 
 libeuclidean.so:
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ src/euclidean.cpp
 
+libmanhattan.so:
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ src/manhattan.cpp
+
 clean:
 	rm -f ./*.so
+	rm -f ./*.out

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS = -shared
 BFLAGS = -L./build
 SFLAGS = -Wl,-rpath,./build
 
-all: libeuclidean.so libmanhattan.so libed.so
+all: libeuclidean.so libmanhattan.so libeditdist.so
 
 test-edr: libeditdist.so libmanhattan.so
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LDFLAGS = -shared
 BFLAGS = -L./build
 SFLAGS = -Wl,-rpath,./build
 
-all: libeuclidean.so libmanhattan.so libeditdist.so
+all: libeuclidean.so libmanhattan.so
 
 test-edr: libeditdist.so libmanhattan.so
 	mkdir -p build

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,31 @@
 CC = g++
+
 CFLAGS = -fPIC -Wall
 LDFLAGS = -shared
 
-all: libeuclidean.so libmanhattan.so
+BFLAGS = -L./build
+SFLAGS = -Wl,-rpath,./build
+
+all: libeuclidean.so libmanhattan.so libed.so
+
+test-edr: libeditdist.so libmanhattan.so
+	mkdir -p build
+	mv libeditdist.so build/
+	mv libmanhattan.so build/ 
+	g++ tests/test_edr.cpp $(BFLAGS) -leditdist -lmanhattan $(SFLAGS) -o $@.out
+
+	./$@.out -d
+
+	rm $@.out build/*.so
 
 libeuclidean.so:
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ src/euclidean.cpp
 
 libmanhattan.so:
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ src/manhattan.cpp
+
+libeditdist.so:
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ src/edit_distance.cpp
 
 clean:
 	rm -f ./*.so

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install -r requirements.txt
 
 Having done this now you can import `cppyy` into your code:
 
-```sh
+```python
 import cppyy
 cppyy.include('src/your_header_file.h') # Enables calls
 cppyy.load_library('your_dynamic_lib.so') # Executes calls

--- a/src/manhattan.cpp
+++ b/src/manhattan.cpp
@@ -1,6 +1,9 @@
 #include "manhattan.h"
 
-// Function to calculate Manhattan distance between two points
+double manhattan_distance(double a, double b) {
+	return std::abs(b - a);
+}
+
 double manhattan_distance(
 	const std::vector<double>& p, const std::vector<double>& q
 )

--- a/src/manhattan.cpp
+++ b/src/manhattan.cpp
@@ -1,7 +1,7 @@
 #include "manhattan.h"
 
 // Function to calculate Manhattan distance between two points
-double distance(
+double manhattan_distance(
 	const std::vector<double>& p, const std::vector<double>& q
 )
 {

--- a/src/manhattan.cpp
+++ b/src/manhattan.cpp
@@ -1,0 +1,18 @@
+#include "manhattan.h"
+
+// Function to calculate Manhattan distance between two points
+double distance(
+	const std::vector<double>& p, const std::vector<double>& q
+)
+{
+	if (p.size() != q.size()) {
+		throw std::invalid_argument("Points must have the same dimensionality");
+	}
+
+	double distance = 0.0;
+	for (size_t i = 0; i < p.size(); ++i) {
+		distance += std::abs(p[i] - q[i]);
+	}
+
+	return distance;
+}

--- a/src/manhattan.h
+++ b/src/manhattan.h
@@ -1,9 +1,9 @@
-#ifndef DISTANCE_H
-#define DISTANCE_H
+#ifndef MANHATTAN_H
+#define MANHATTAN_H
 
 #include <vector>
 #include <stdexcept>
 
 double manhattan_distance(const std::vector<double>& p, const std::vector<double>& q);
 
-#endif  // DISTANCE_H
+#endif  // MANHATTAN_H

--- a/src/manhattan.h
+++ b/src/manhattan.h
@@ -1,0 +1,9 @@
+#ifndef DISTANCE_H
+#define DISTANCE_H
+
+#include <vector>
+#include <stdexcept>
+
+double distance(const std::vector<double>& p, const std::vector<double>& q);
+
+#endif  // DISTANCE_H

--- a/src/manhattan.h
+++ b/src/manhattan.h
@@ -4,6 +4,6 @@
 #include <vector>
 #include <stdexcept>
 
-double distance(const std::vector<double>& p, const std::vector<double>& q);
+double manhattan_distance(const std::vector<double>& p, const std::vector<double>& q);
 
 #endif  // DISTANCE_H

--- a/src/manhattan.h
+++ b/src/manhattan.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <stdexcept>
 
+double manhattan_distance(double a, double b);
+
 double manhattan_distance(const std::vector<double>& p, const std::vector<double>& q);
 
 #endif  // MANHATTAN_H

--- a/tests/test_manhattan.cpp
+++ b/tests/test_manhattan.cpp
@@ -12,9 +12,11 @@
 */
 
 int main() {
-	// Sample arrays
-	std::vector<double> p = {1.0, 2.0}; // (x_1, y_1)
-	std::vector<double> q = {3.0, 4.0}; // (x_2, y_2)
+	// std::vector<double> p = {1.0, 2.0}; // (x_1, y_1)
+	// std::vector<double> q = {3.0, 4.0}; // (x_2, y_2)
+
+	std::vector<double> p = {1.4231, 2.123}; // (x_1, y_1)
+	std::vector<double> q = {10.213, 11.123}; // (x_2, y_2)
 
 	double res = distance(p, q);
 	if (res >= 0.0) {

--- a/tests/test_manhattan.cpp
+++ b/tests/test_manhattan.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+
+#include "../src/manhattan.h"
+
+/*
+ * To run this:
+ * > make
+ * > mv libmanhattan.so build/
+ * > export LD_LIBRARY_PATH=./build:$LD_LIBRARY_PATH
+ * > g++ tests/test_manhattan.cpp -L./build -lmanhattan
+ * > ./a.out
+*/
+
+int main() {
+	// Sample arrays
+	std::vector<double> p = {1.0, 2.0}; // (x_1, y_1)
+	std::vector<double> q = {3.0, 4.0}; // (x_2, y_2)
+
+	double res = distance(p, q);
+	if (res >= 0.0) {
+		std::cout << "Manhattan Distance: " << res << std::endl;
+	}
+
+	return 0;
+}

--- a/tests/test_manhattan.cpp
+++ b/tests/test_manhattan.cpp
@@ -18,7 +18,7 @@ int main() {
 	std::vector<double> p = {1.4231, 2.123}; // (x_1, y_1)
 	std::vector<double> q = {10.213, 11.123}; // (x_2, y_2)
 
-	double res = distance(p, q);
+	double res = manhattan_distance(p, q);
 	if (res >= 0.0) {
 		std::cout << "Manhattan Distance: " << res << std::endl;
 	}

--- a/tests/test_manhattan.py
+++ b/tests/test_manhattan.py
@@ -5,7 +5,7 @@ cppyy.load_library('libmanhattan.so')
 lib = cppyy.gbl
 
 def test_integers():
-    assert lib.distance([1,2], [3,4]) == 4
+    assert lib.manhattan_distance([1,2], [3,4]) == 4
 
 def test_floats():
-    assert lib.distance([1.4231, 2.123], [10.213, 11.123]) == 17.7899
+    assert lib.manhattan_distance([1.4231, 2.123], [10.213, 11.123]) == 17.7899

--- a/tests/test_manhattan.py
+++ b/tests/test_manhattan.py
@@ -1,0 +1,11 @@
+import cppyy
+
+cppyy.include('src/manhattan.h')
+cppyy.load_library('libmanhattan.so')
+lib = cppyy.gbl
+
+def test_integers():
+    assert lib.distance([1,2], [3,4]) == 4
+
+def test_floats():
+    assert lib.distance([1.4231, 2.123], [10.213, 11.123]) == 17.7899


### PR DESCRIPTION
Implementando el algoritmo de _Edit Distance with Real Penalty_ y haciendo algunas pruebas, me dí cuenta que hay un error al ejecutar las pruebas con cppyy (ya más detallado en #18). Esta PR parcha este error, para que no tengan estos errores al estar implementando nuevos algoritmos y que las pruebas no les funcionen. También les puede servir esta PR como guía de lo mínimo que se debe modificar para incluir un nuevo algoritmo.

Esta PR parcha este error y deja implementando el algoritmo Manhattan que se usa en EDRP.